### PR TITLE
상단 navigation tab 기본 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         compose_version = '1.1.1'
         hilt_version = "2.41"
         room_version = "2.4.2"
+        navigation_version = "2.5.0-rc02"
     }
 
     dependencies {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
 
     //hilt
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -68,5 +68,8 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
+    //navigation
+    implementation "androidx.navigation:navigation-compose:$navigation_version"
+
     implementation project(path: ':domain')
 }

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListActivity.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListActivity.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import com.pyc.playyourcolor.playlist.view.ui.theme.PlayYourColorTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -18,28 +20,17 @@ class PlayListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            PlayYourColorTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colors.background
-                ) {
-                    Greeting("Android")
-                }
-            }
+            PlayYourColorApp()
         }
     }
 }
 
 @Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
+fun PlayYourColorApp() {
     PlayYourColorTheme {
-        Greeting("Android")
+        val allScreens = PlayListScreen.values().toList()
+        val navController = rememberNavController()
+        val backstackEntry = navController.currentBackStackEntryAsState()
+        val currentScreen = PlayListScreen.fromRoute(backstackEntry.value?.destination?.route)
     }
 }

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListActivity.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListActivity.kt
@@ -3,15 +3,19 @@ package com.pyc.playyourcolor.playlist.view
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.*
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.pyc.playyourcolor.playlist.view.ui.colorplaylist.ColorPlayListScreen
+import com.pyc.playyourcolor.playlist.view.ui.components.PlayListTabRow
+import com.pyc.playyourcolor.playlist.view.ui.primaryplaylist.PrimaryPlayListScreen
+import com.pyc.playyourcolor.playlist.view.ui.settings.SettingsScreen
 import com.pyc.playyourcolor.playlist.view.ui.theme.PlayYourColorTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -32,5 +36,38 @@ fun PlayYourColorApp() {
         val navController = rememberNavController()
         val backstackEntry = navController.currentBackStackEntryAsState()
         val currentScreen = PlayListScreen.fromRoute(backstackEntry.value?.destination?.route)
+
+        Scaffold(
+            topBar = {
+                PlayListTabRow(
+                    allScreens = allScreens,
+                    onTabSelected = { screen ->
+                        navController.navigate(screen.name)
+                    },
+                    currentScreen = currentScreen
+                )
+            }
+        ) { innerPadding ->
+            NaveHost(navController, modifier = Modifier.padding(innerPadding))
+        }
+    }
+}
+
+@Composable
+fun NaveHost(navController: NavHostController, modifier: Modifier) {
+    NavHost(
+        navController = navController,
+        startDestination = PlayListScreen.Primary.name,
+        modifier = modifier
+    ) {
+        composable(PlayListScreen.Primary.name) {
+            PrimaryPlayListScreen()
+        }
+        composable(PlayListScreen.Color.name) {
+            ColorPlayListScreen()
+        }
+        composable(PlayListScreen.Settings.name) {
+            SettingsScreen()
+        }
     }
 }

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListScreen.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListScreen.kt
@@ -1,0 +1,19 @@
+package com.pyc.playyourcolor.playlist.view
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LibraryMusic
+import androidx.compose.material.icons.filled.PlaylistPlay
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class PlayListScreen (val icon: ImageVector) {
+    Primary(
+        icon = Icons.Filled.LibraryMusic,
+    ),
+    Color(
+        icon = Icons.Filled.PlaylistPlay,
+    ),
+    Settings(
+        icon = Icons.Filled.Settings
+    )
+}

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListScreen.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/PlayListScreen.kt
@@ -5,15 +5,33 @@ import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.pyc.playyourcolor.R
 
-enum class PlayListScreen (val icon: ImageVector) {
+enum class PlayListScreen (
+    val icon: ImageVector,
+    val id: Int,
+) {
     Primary(
         icon = Icons.Filled.LibraryMusic,
+        id = R.string.primary_playlist,
     ),
     Color(
         icon = Icons.Filled.PlaylistPlay,
+        id = R.string.color_playlist,
     ),
     Settings(
-        icon = Icons.Filled.Settings
-    )
+        icon = Icons.Filled.Settings,
+        id = R.string.settings
+    );
+
+    companion object {
+        fun fromRoute(route: String?): PlayListScreen =
+            when (route?.substringBefore("/")) {
+                Primary.name -> Primary
+                Color.name -> Color
+                Settings.name -> Settings
+                null -> Primary
+                else -> throw IllegalArgumentException("Route $route is not recognized.")
+            }
+    }
 }

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/colorplaylist/ColorPlayLIstScreen.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/colorplaylist/ColorPlayLIstScreen.kt
@@ -1,0 +1,9 @@
+package com.pyc.playyourcolor.playlist.view.ui.colorplaylist
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ColorPlayListScreen() {
+    Text(text = "컬러 플레이리스트 화면")
+}

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/components/PlayListTabRow.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/components/PlayListTabRow.kt
@@ -1,0 +1,106 @@
+package com.pyc.playyourcolor.playlist.view.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pyc.playyourcolor.playlist.view.PlayListScreen
+import java.util.*
+
+@Preview
+@Composable
+fun PlayListTabRow(
+    allScreens: List<PlayListScreen> = PlayListScreen.values().toList(),
+    onTabSelected: (PlayListScreen) -> Unit = {},
+    currentScreen: PlayListScreen = PlayListScreen.Primary
+) {
+    Surface(
+        Modifier
+            .wrapContentHeight()
+            .fillMaxWidth()
+    ) {
+        Row(Modifier.selectableGroup()) {
+            allScreens.forEach { screen ->
+                PlayListTab(
+                    text = stringResource(id = screen.id),
+                    icon = screen.icon,
+                    onSelected = { onTabSelected(screen) },
+                    selected = currentScreen == screen
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlayListTab(
+    text: String,
+    icon: ImageVector,
+    onSelected: () -> Unit,
+    selected: Boolean
+) {
+    val color = MaterialTheme.colors.onSurface
+    val durationMillis = if (selected) TabFadeInAnimationDuration else TabFadeOutAnimationDuration
+    val animSpec = remember {
+        tween<Color>(
+            durationMillis = durationMillis,
+            easing = LinearEasing,
+            delayMillis = TabFadeInAnimationDelay
+        )
+    }
+    val tabTintColor by animateColorAsState(
+        targetValue = if (selected) color else color.copy(alpha = InactiveTabOpacity),
+        animationSpec = animSpec
+    )
+    Row(
+        modifier = Modifier
+            .padding(16.dp)
+            .animateContentSize()
+            .wrapContentHeight()
+            .selectable(
+                selected = selected,
+                onClick = onSelected,
+                role = Role.Tab,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(
+                    bounded = true,
+                    radius = Dp.Unspecified,
+                    color = Color.White
+                )
+            )
+            .clearAndSetSemantics { contentDescription = text }
+    ) {
+        Icon(imageVector = icon, contentDescription = text, tint = tabTintColor)
+        if (selected) {
+            Spacer(Modifier.width(12.dp))
+            Text(text.uppercase(Locale.getDefault()), color = tabTintColor)
+        }
+    }
+}
+
+private const val InactiveTabOpacity = 0.60f
+private const val TabFadeInAnimationDuration = 150
+private const val TabFadeInAnimationDelay = 100
+private const val TabFadeOutAnimationDuration = 100

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/primaryplaylist/PrimaryPlayListScreen.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/primaryplaylist/PrimaryPlayListScreen.kt
@@ -1,0 +1,9 @@
+package com.pyc.playyourcolor.playlist.view.ui.primaryplaylist
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun PrimaryPlayListScreen() {
+    Text(text = "기본 재생 화면")
+}

--- a/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/com/pyc/playyourcolor/playlist/view/ui/settings/SettingsScreen.kt
@@ -1,0 +1,9 @@
+package com.pyc.playyourcolor.playlist.view.ui.settings
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SettingsScreen() {
+    Text(text = "세팅 화면")
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="app_name">PlayYourColor</string>
     <string name="title_activity_play_list">PlayListActivity</string>
+    <string name="primary_playlist">SONGS</string>
+    <string name="color_playlist">COLOR PLAYLIST</string>
+    <string name="settings">SETTINGS</string>
 </resources>


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가 
- [ ] 버그 수정
- [ ] 의존성, 빌드 관련 코드 업데이트 
- [ ] 기타 사소한 수정 

## 개요 
- #7 

## 변경 사항 
- 화면 정보를 Enum 으로 구성했고 Enum 의 name 필드를 키로 하여 navigation 하도록 했습니다. 
- 코드랩에 탭 했을 때 일어나는 괜찮은 애니메이션 래퍼런스가 있어서 적용해보았습니다 

## 코드 리뷰시 참고 사항 
`래퍼런스`
- https://developer.android.com/codelabs/jetpack-compose-navigation?hl=ko#2 
- https://www.youtube.com/watch?v=HOocoNbKd-M&list=PLgOlaPUIbynpFHXeEORmvIOoiNVgSsWeq&index=14 
## 스크린샷
![Jun-18-2022 18-18-09](https://user-images.githubusercontent.com/55446114/174431303-fec1b880-9a72-4188-9d6c-f38ba271ea2d.gif)

